### PR TITLE
load js from HTTPS source

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     </form>
     <ul id="notes" class="notes"></ul>
 
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="js/retain.js"></script>
 </body>
 </html>


### PR DESCRIPTION
If the page is hosted with HTTPS enabled site, such as GitHub Pages, then the library will not be loaded because it is from insecure source. In order to solve this problem, external library needs to be loaded with HTTPS.

By the way, I think it is a best particle to use HTTPS connection if possible.
